### PR TITLE
Add alternative to executing standalone connections

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,11 +147,9 @@ exports.executeStandaloneConnection = async (
   }
 
   const connection = await oracledb.getConnection({
-    user: config.DATASOURCES[sourceName].DB_USER,
-    password: config.DATASOURCES[sourceName].DB_PASSWORD,
-    connectString: `${srcCfg.DB_HOST}:${srcCfg.DB_PORT}/${srcCfg.DB_DATABASE}`,
-
-    connectString: `${config.DATASOURCES[sourceName].DB_HOST}:${config.DATASOURCES[sourceName].DB_PORT}/${config.DATASOURCES[sourceName].DB_DATABASE}`,
+    user: srcCfg.DB_USER,
+    password: srcCfg.DB_PASSWORD,
+    connectString: `${srcCfg.DB_HOST}:${srcCfg.DB_PORT}/${srcCfg.DB_DATABASE}`
   });
   const start = process.hrtime();
 

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ exports.init = async (cfg) => {
 
 exports.execute = async (srcName, query, params = {}, options = {}) => {
   let result;
+  let conn;
   try {
     console.debug(query);
     if (params) {
@@ -86,7 +87,7 @@ exports.execute = async (srcName, query, params = {}, options = {}) => {
     }
 
     const start = process.hrtime();
-    const conn = await this.connect(srcName);
+    conn = await this.connect(srcName);
 
     console.debug(
       `Oracle Adapter: Connection secured: ${process.hrtime(start)[0]}s ${
@@ -100,12 +101,13 @@ exports.execute = async (srcName, query, params = {}, options = {}) => {
       process.hrtime(start)[1] / 1000000
       }ms`
     );
+
+    return result;
   } catch (err) {
     console.error("Oracle Adapter: Error while executing query", err);
     throw new Error(err.message);
   } finally {
     await conn.close();
-    return result;
   }
 };
 


### PR DESCRIPTION
Add alternative to executing standalone connections in cases where wanting to provide a solution for concurrent requests to the same data source, as using the built-in `execute` method will execute connections to a pool previously established. However, due to the number of concurrent requests that could happen to the same pool, we can max out the limit of connections available for each pool, which by default it is set to 4 based on Oracle's Documentation https://oracle.github.io/node-oracledb/doc/api.html#propdbpoolmax