### PR TITLE
Add ability to customize max number of concurrent connections open in a pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ combined.log
 database.log
 perf.log
 http.log
+
+test.js


### PR DESCRIPTION
Add the ability to customize the max number of concurrent connections open in a pool, with the purpose of not limiting modules using the package to set up a pool with the oracledb package default `poolMax`, `poolMin`, and `poolIncrement` default values .