### PR TITLE
Oracledb upgrade

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ exports.execute = async (srcName, query, params = {}, options = {}) => {
     console.error("Oracle Adapter: Error while executing query", err);
     throw new Error(err.message);
   } finally {
-    await conn.close();
+    if (conn) await conn.close();
   }
 };
 
@@ -194,7 +194,7 @@ exports.executeMany = async (srcName, query, binds = [], options = {}) => {
     console.error("Oracle Adapter: Error while executing query", err);
     throw new Error(err.message);
   } finally {
-    await conn.close();
+    if (conn) await conn.close();
   }
 };
 
@@ -231,7 +231,7 @@ exports.executeStoredProc = async (srcName, storeproc, params = {}, options = {}
     console.error("Oracle Adapter: Error while executing query", err);
     throw new Error(err.message);
   } finally {
-     await conn.close();
+     if (conn) await conn.close();
      return rows;
   }
 };
@@ -300,7 +300,7 @@ exports.executeStandaloneConnection = async (
   } catch (ex) {
     console.error(`Oracle Adapter: There was an error at the moment of executing oracle query using a standalone connection: ${JSON.stringify(ex)}`);
   } finally {
-    await connection.close();
+    if (connection) await connection.close();
     return result;
   }
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/softrams/nodejs-oracle-connector#readme",
   "dependencies": {
-    "oracledb": "^4.2.0"
+    "oracledb": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softrams/nodejs-oracle-connector",
-  "version": "0.0.11",
+  "version": "1.0.0",
   "description": "Database connector wrapper to work with Oracle database from nodejs applications",
   "main": "index.js",
   "scripts": {
@@ -23,5 +23,8 @@
   "homepage": "https://github.com/softrams/nodejs-oracle-connector#readme",
   "dependencies": {
     "oracledb": "^5.2.0"
+  },
+  "engines": {
+    "node": ">=10.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softrams/nodejs-oracle-connector",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Database connector wrapper to work with Oracle database from nodejs applications",
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-oracledb@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/oracledb/-/oracledb-4.2.0.tgz#b4d97957d206f7c2d1c2286cc80e91ff2d45fce8"
-  integrity sha512-07ZylNcUB9wknsiRa7dNqDWgGK3loP8eNWuoCjsiCOZ19PA1g8QLu+0gah7ty82VXl/MOQYFCMl5OpjD9Aqjcw==
+oracledb@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/oracledb/-/oracledb-5.2.0.tgz#c5774a38508e2ebd4f899500dfc35daa03b00481"
+  integrity sha512-gHOWTM6ILKOGVH3Z+11Cnpls8XWW7sZUoBrbQWvspYOGpkvJ+TKRr1OdVS21EyeAtfMzXePDrSvG/Mlp/fxOVA==


### PR DESCRIPTION
Changes: 

1. Fixed typeError when there is an error and connection is not defined.
2. Upgraded oracledb package 4.2.0 --> 5.2.0

oracledb changelogs related to this upgrade are 5.0.0 - 5.2.0
[CHANGELOG](https://github.com/oracle/node-oracledb/blob/main/CHANGELOG.md)

It is recommended to use instant client v19.12 or greater with the new oracledb package